### PR TITLE
Add Flutter mobile skeleton

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,9 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.packages
+.flutter-plugins
+.flutter-plugins-dependencies
+.melos_tool
+.idea/
+.DS_Store

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,22 @@
+# EyeSpeak Assist Mobile
+
+This directory contains a simplified Flutter implementation of **EyeSpeak Assist** for Android and iOS. It provides a scanning on‑screen keyboard and uses blink detection to select keys.
+
+The project depends on Google's ML Kit for blink detection and the platform text‑to‑speech engine.
+
+## Building
+
+1. Install Flutter (>=3.10) and the Android/iOS SDKs.
+2. Run `flutter pub get` inside this `mobile` directory.
+3. Connect a device or start an emulator.
+4. Run `flutter run` to launch the app.
+
+A release build can be generated with `flutter build apk` or `flutter build ios`.
+
+## Compliance Notes
+
+- The camera feed is processed only for real‑time blink detection and is not stored.
+- A camera usage description must be provided in the Android manifest and iOS `Info.plist` when publishing to the stores.
+- Audio is generated using the native text‑to‑speech services (`FlutterTts`).
+
+This mobile code is provided under the same **CC BY‑NC 4.0** license as the desktop version.

--- a/mobile/assets/phrases.json
+++ b/mobile/assets/phrases.json
@@ -1,0 +1,29 @@
+{
+  "phrases": [
+    "I Need to go to the bathroom",
+    "My Back Hurts",
+    "My Butt Hurts",
+    "I Want Pepsi",
+    "I Want hot water",
+    "I want to shower",
+    "I need to brush my teeth",
+    "I need my meds",
+    "I need a drop",
+    "I need a puff",
+    "I want a mango shake",
+    "I want a banana shake",
+    "I want to take a nap",
+    "I am Hot",
+    "I am cold",
+    "I need the heating pad on my back",
+    "Yes",
+    "No",
+    "I WANT TO SIT UP",
+    "Right Leg",
+    "Left Leg",
+    "Right Arm",
+    "Left Arm",
+    "I NEED HELP",
+    "I AM IN PAIN"
+  ]
+}

--- a/mobile/lib/blink_detector.dart
+++ b/mobile/lib/blink_detector.dart
@@ -1,0 +1,69 @@
+import "dart:ui" show Size;
+import 'dart:async';
+import 'package:camera/camera.dart';
+import 'package:google_mlkit_face_detection/google_mlkit_face_detection.dart';
+
+/// Simple blink detector using ML Kit face detection.
+/// Calls [onBlink] whenever both eyes are closed for more than 0.5s.
+class BlinkDetector {
+  final void Function() onBlink;
+  late final FaceDetector _detector;
+  CameraController? _controller;
+  bool _processing = false;
+  DateTime _lastBlink = DateTime.now();
+
+  BlinkDetector({required this.onBlink}) {
+    _detector = FaceDetector(options: const FaceDetectorOptions());
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    final cams = await availableCameras();
+    if (cams.isEmpty) return;
+    _controller = CameraController(cams.first, ResolutionPreset.medium);
+    await _controller!.initialize();
+    await _controller!.startImageStream(_processImage);
+  }
+
+  Future<void> _processImage(CameraImage image) async {
+    if (_processing) return;
+    _processing = true;
+    try {
+      final inputImage = _toInputImage(image, _controller!);
+      final faces = await _detector.processImage(inputImage);
+      if (faces.isNotEmpty) {
+        final f = faces.first;
+        final left = f.leftEyeOpenProbability ?? 1.0;
+        final right = f.rightEyeOpenProbability ?? 1.0;
+        if (left < 0.4 && right < 0.4) {
+          if (DateTime.now().difference(_lastBlink).inMilliseconds > 500) {
+            _lastBlink = DateTime.now();
+            onBlink();
+          }
+        }
+      }
+    } catch (_) {} finally {
+      _processing = false;
+    }
+  }
+
+  InputImage _toInputImage(CameraImage image, CameraController controller) {
+    final format = InputImageFormatValue.fromRawValue(image.format.raw) ?? InputImageFormat.nv21;
+    return InputImage.fromBytes(
+      bytes: image.planes[0].bytes,
+      inputImageData: InputImageData(
+        size: Size(controller.value.previewSize!.height, controller.value.previewSize!.width),
+        imageRotation: InputImageRotationValue.fromRawValue(controller.description.sensorOrientation) ?? InputImageRotation.rotation0deg,
+        inputImageFormat: format,
+        planeData: image.planes.map(
+          (p) => InputImagePlaneMetadata(bytesPerRow: p.bytesPerRow, height: p.height, width: p.width),
+        ).toList(),
+      ),
+    );
+  }
+
+  void dispose() {
+    _controller?.dispose();
+    _detector.close();
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+import 'blink_detector.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const EyeSpeakApp());
+}
+
+class EyeSpeakApp extends StatelessWidget {
+  const EyeSpeakApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'EyeSpeak Assist Mobile',
+      theme: ThemeData.dark(),
+      home: const KeyboardScreen(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+class KeyboardScreen extends StatefulWidget {
+  const KeyboardScreen({super.key});
+
+  @override
+  State<KeyboardScreen> createState() => _KeyboardScreenState();
+}
+
+class _KeyboardScreenState extends State<KeyboardScreen> {
+  final List<List<String>> _layout = [
+    'QWERTYUIOP'.split(''),
+    'ASDFGHJKL'.split(''),
+    'ZXCVBNM./-'.split(''),
+  ];
+
+  int _row = 0;
+  int _col = 0;
+  String _text = '';
+  late Timer _timer;
+  late FlutterTts _tts;
+  BlinkDetector? _detector;
+
+  @override
+  void initState() {
+    super.initState();
+    _tts = FlutterTts();
+    _detector = BlinkDetector(onBlink: _onBlink);
+    _timer = Timer.periodic(const Duration(milliseconds: 1500), (timer) {
+      setState(() {
+        _col++;
+        if (_col >= _layout[_row].length) {
+          _col = 0;
+          _row = (_row + 1) % _layout.length;
+        }
+      });
+    });
+    SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeLeft, DeviceOrientation.landscapeRight]);
+  }
+
+  void _onBlink() {
+    final ch = _layout[_row][_col];
+    setState(() {
+      if (ch == '-') {
+        _tts.speak(_text);
+        _text = '';
+      } else if (ch == '.') {
+        _text += ' ';
+      } else if (ch == '/') {
+        if (_text.isNotEmpty) {
+          _text = _text.substring(0, _text.length - 1);
+        }
+      } else {
+        _text += ch;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    _detector?.dispose();
+    super.dispose();
+  }
+
+  Widget _buildKey(String char, bool highlight) {
+    return Container(
+      margin: const EdgeInsets.all(4),
+      width: 50,
+      height: 50,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        border: Border.all(color: highlight ? Colors.green : Colors.white, width: 2),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(char, style: const TextStyle(fontSize: 20)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(_text, style: const TextStyle(fontSize: 24, color: Colors.yellow)),
+            ),
+            for (int r = 0; r < _layout.length; r++)
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  for (int c = 0; c < _layout[r].length; c++)
+                    _buildKey(_layout[r][c], r == _row && c == _col),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,0 +1,18 @@
+name: eye_speak_mobile
+description: Flutter mobile implementation of EyeSpeak Assist.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  google_mlkit_face_detection: ^0.3.0
+  camera: ^0.10.5
+  flutter_tts: ^3.6.3
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/phrases.json


### PR DESCRIPTION
## Summary
- add simplified Flutter project under `mobile/`
- include blink detection and scanning keyboard in Dart
- document mobile build steps and compliance notes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68715e10ed7c83209570b33453a29efc